### PR TITLE
Update winit version to support Apple Silicon

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ edition = "2018"
 [dependencies]
 ash = "0.31"
 ash-window = "0.5"
-winit = "0.22"
+winit = "0.24"
 image = "0.23"
 rand = "0.7.3"
 miniz_oxide = "0.4.3"

--- a/src/main.rs
+++ b/src/main.rs
@@ -26,7 +26,7 @@ use ash::vk;
 use winit::{
     event::{ElementState, Event, MouseButton, MouseScrollDelta, VirtualKeyCode, WindowEvent},
     event_loop::{ControlFlow, EventLoop},
-    platform::desktop::EventLoopExtDesktop,
+    platform::run_return::EventLoopExtRunReturn,
     window::WindowBuilder,
 };
 
@@ -297,7 +297,7 @@ fn main() {
     struct Camera {
         position: Vec3,
         direction: Vec3,
-    };
+    }
 
     let mut camera = Camera {
         position: Vec3 {
@@ -320,7 +320,7 @@ fn main() {
         wheel_delta: f32,
         keyboard_forward: i32,
         keyboard_side: i32,
-    };
+    }
 
     impl Default for Inputs {
         fn default() -> Inputs {
@@ -332,7 +332,7 @@ fn main() {
                 keyboard_side: 0,
             }
         }
-    };
+    }
 
     // Window event loop
     println!("Start window event loop");


### PR DESCRIPTION
Hey, hope PRs are welcome but if they are not feel free to discard. I ran this on Apple's new(ish) M1 chips and ran into some hiccups, so I fixed them. 👋

`winit` had a minor compilation error on macOS aarch64 in versions prior to 0.24. 0.24 introduces the fix, but includes breaking changes over 0.22, so this change updates the `EventLoopExtDesktop` trait to the new `EventLoopExtRunReturn` trait.

Also removed some extra `;` that rustc was warning about.

Some fun numbers for those curious:
```
MacBook Air (M1, 2020)
VulkanSDK: 1.2.182.0

Both
    cargo run --release --target=x86_64-apple-darwin
    cargo run --release --target=aarch64-apple-darwin
average about 40ms frame times on my machine
```

There's some flickering that looks related to culling but that's beyond the scope of this PR.